### PR TITLE
Add minimal backend and frontend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node dependencies
+node_modules/
+
+# Logs
+*.log
+
+# Environment files
+.env
+.env.*

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.get('/', (req, res) => {
+  res.send('Backend is running');
+});
+
+app.listen(port, () => {
+  console.log(`Server started on port ${port}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "app.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E-Catalog Frontend</title>
+</head>
+<body>
+  <h1>Frontend is running</h1>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "echo 'Open index.html in a browser'"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add basic `.gitignore` for node and env files
- scaffold `backend/` with Express starter and package.json
- scaffold `frontend/` with index.html and package.json

## Testing
- `npm install` in `backend`
- `npm install` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b7af7aaa4832cb5cb7876e9ca1f03